### PR TITLE
Return the same units as the FIT gem.

### DIFF
--- a/lib/tcx/tcx_file.rb
+++ b/lib/tcx/tcx_file.rb
@@ -8,12 +8,14 @@ module Tcx
       Ox.sax_parse(@handler, io)
     end
 
+    # In milliseconds to provide the same interface as FIT.
     def active_duration
-      @active_duration ||= @handler.laps.inject(0) { |k,v| k + v.total_time_seconds }
+      total_time_in_seconds * 100
     end
 
+    # In cm to provide the same interface as FIT.
     def distance
-      @distance ||= @handler.laps.inject(0) { |k,v| k + v.distance_meters }
+      total_distance_in_meters * 100
     end
 
     def start_time
@@ -21,7 +23,17 @@ module Tcx
     end
 
     def end_time
-      start_time + active_duration
+      start_time + total_time_in_seconds
+    end
+
+    private
+
+    def total_time_in_seconds
+      @total_time_in_seconds ||= @handler.laps.inject(0) { |k,v| k + v.total_time_seconds }
+    end
+
+    def total_distance_in_meters
+      @total_distance_in_meters ||= @handler.laps.inject(0) { |k,v| k + v.distance_meters }
     end
   end
 

--- a/spec/tcx_file_spec.rb
+++ b/spec/tcx_file_spec.rb
@@ -7,13 +7,13 @@ describe Tcx::TcxFile do
   describe "#active_duration" do
     subject { tcx_file.active_duration }
 
-    it { should == 2325.0200000 }
+    it { should == 232502.00000 }
   end
 
   describe "#distance" do
     subject { tcx_file.distance }
 
-    it { should == 8348.5039063 }
+    it { should == 834850.39063 }
   end
 
   describe "#start_time" do


### PR DESCRIPTION
In order to provide the same interface as the [FIT](https://github.com/aerobicio/fit) gem, we now return distance and duration in cm and ms accordingly.
